### PR TITLE
Add CLI support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,14 @@
     "": {
       "name": "mermaid-js-erd-to-sql",
       "version": "1.1.3",
+      "dependencies": {
+        "ts-node": "^10.9.2"
+      },
       "devDependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "^18.19.34",
         "@types/vscode": "^1.89.0",
+        "@types/yargs": "^17.0.33",
         "@typescript-eslint/eslint-plugin": "^7.7.1",
         "@typescript-eslint/parser": "^7.7.1",
         "@vscode/test-cli": "^0.0.9",
@@ -29,6 +33,28 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -590,7 +616,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -598,8 +623,7 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -656,6 +680,30 @@
         "node": ">=14"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -672,7 +720,6 @@
       "version": "18.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
       "integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -682,6 +729,23 @@
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.90.0.tgz",
       "integrity": "sha512-oT+ZJL7qHS9Z8bs0+WKf/kQ27qWYR3trsXpq46YDjFqBsMLG4ygGGjPaJ2tyrH0wJzjOEmDyg9PDJBBhWg9pkQ==",
       "dev": true
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.14.1",
@@ -917,7 +981,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
       "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -932,6 +995,18 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -1007,6 +1082,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1420,6 +1501,12 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3096,6 +3183,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "license": "ISC"
+    },
     "node_modules/memorystream": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -4741,6 +4834,58 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4842,7 +4987,6 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
       "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4869,8 +5013,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -4886,6 +5029,12 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -5145,6 +5294,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     ]
   },
   "scripts": {
+    "cli": "ts-node ./src/cli.ts",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "vscode-test",
@@ -56,6 +57,7 @@
     "@types/mocha": "^10.0.6",
     "@types/node": "^18.19.34",
     "@types/vscode": "^1.89.0",
+    "@types/yargs": "^17.0.33",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",
     "@vscode/test-cli": "^0.0.9",
@@ -64,5 +66,8 @@
     "eslint": "^8.57.0",
     "npm-run-all": "^4.1.5",
     "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "ts-node": "^10.9.2"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+import * as convert from './convert/index';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import * as fs from 'fs';
+
+const argv = yargs(hideBin(process.argv))
+  .command('$0 <file>', 'Convert a Mermaid ERD to SQL', (yargs) => {
+    yargs.positional('file', {
+      describe: 'Path to Mermaid ERD file',
+      type: 'string',
+    });
+  })
+  .option('flavor', {
+    alias: 'f',
+    type: 'string',
+    default: 'sql',
+    describe: 'SQL flavor',
+  })
+  .parseSync();
+
+
+let convertFunction = null;
+switch (argv.flavor) {
+  case 'postgres':
+    convertFunction = convert.MermaidERDPostgreSQL.toSQL;
+    break;
+  case 'mysql':
+    convertFunction = convert.MermaidERDPostgreSQL.toSQL;
+    break;
+  case 'sqlite':
+    convertFunction = convert.MermaidERDPostgreSQL.toSQL;
+    break;
+  case 'sql':
+    convertFunction = convert.MermaidERDPostgreSQL.toSQL;
+    break;
+}
+
+if (convertFunction = null) {
+  console.error(`Unsupported SQL flavor: ${argv.flavor}.`);
+  process.exit(1);
+}
+
+const filePath = argv.file as string;
+const { outputFilename, markdownContent } = getMermaidFileContent(filePath);
+if (outputFilename === '' || markdownContent === '') {
+  console.error("Error while reading Mermaid file content.");
+  process.exit(1);
+}
+const { schema, entities, relationships } = convert.parseMermaidERD(markdownContent);
+const sqlScript = convert.MermaidERDSQL.toSQL(schema, entities, relationships);
+writeGeneratedFile(outputFilename, sqlScript);
+
+/**
+ * Write the SQL script to a file
+ * @param outputFilename 
+ * @param content 
+ */
+function writeGeneratedFile(outputFilename: string, content: string) {
+  fs.writeFileSync(outputFilename, content); //write SQL file in currently opened file folder
+}
+
+/**
+ * Get Mermaid JS ERD Markdown content from currently opened file
+ * @param extension file extension for the output file
+ * @returns 
+ */
+function getMermaidFileContent(path: string, extension: string = '.sql'): { outputFilename: string, markdownContent: string } {
+  const fileExt = path?.split('.').pop();
+  if (fileExt !== 'mmd' && fileExt !== 'mermaid' && fileExt !== 'md') {
+    return { outputFilename: '', markdownContent: '' };
+  }
+  let dateTime = '';
+  const outputFilename = path?.substring(0, path.lastIndexOf('.')) + dateTime + extension;
+  const markdownContent = path ? fs.readFileSync(path, 'utf-8') : '';
+  return { outputFilename, markdownContent };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import * as convert from './convert/index';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import * as convert from './convert/index';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
@@ -21,36 +19,30 @@ const argv = yargs(hideBin(process.argv))
   .parseSync();
 
 
-let convertFunction = null;
-switch (argv.flavor) {
-  case 'postgres':
-    convertFunction = convert.MermaidERDPostgreSQL.toSQL;
-    break;
-  case 'mysql':
-    convertFunction = convert.MermaidERDPostgreSQL.toSQL;
-    break;
-  case 'sqlite':
-    convertFunction = convert.MermaidERDPostgreSQL.toSQL;
-    break;
-  case 'sql':
-    convertFunction = convert.MermaidERDPostgreSQL.toSQL;
-    break;
-}
-
-if (convertFunction = null) {
-  console.error(`Unsupported SQL flavor: ${argv.flavor}.`);
-  process.exit(1);
-}
-
 const filePath = argv.file as string;
 const { outputFilename, markdownContent } = getMermaidFileContent(filePath);
 if (outputFilename === '' || markdownContent === '') {
   console.error("Error while reading Mermaid file content.");
   process.exit(1);
 }
+
 const { schema, entities, relationships } = convert.parseMermaidERD(markdownContent);
-const sqlScript = convert.MermaidERDSQL.toSQL(schema, entities, relationships);
-writeGeneratedFile(outputFilename, sqlScript);
+if (argv.flavor === 'postgres') {
+  const sqlScript = convert.MermaidERDPostgreSQL.toSQL(schema, entities, relationships);
+  writeGeneratedFile(outputFilename, sqlScript);
+} else if (argv.flavor === 'mysql') {
+  const sqlScript = convert.MermaidERDMySQL.toSQL(schema, entities, relationships);
+  writeGeneratedFile(outputFilename, sqlScript);
+} else if (argv.flavor === 'sqlite') {
+  const sqlScript = convert.MermaidERDSQLite.toSQL(schema, entities, relationships);
+  writeGeneratedFile(outputFilename, sqlScript);
+} else if (argv.flavor === 'sql') {
+  const sqlScript = convert.MermaidERDSQL.toSQL(schema, entities, relationships);
+  writeGeneratedFile(outputFilename, sqlScript);
+} else {
+  console.error(`Unsupported SQL flavor: ${argv.flavor}.`);
+  process.exit(1);
+}
 
 /**
  * Write the SQL script to a file


### PR DESCRIPTION
This PR adds a standalone CLI entry point (cli.ts), allowing users to convert Mermaid ERD files to SQL directly from the command line, without needing VSCode.

- Introduces cli.ts to run conversions from the command line.
- Adds `ts-node` and `@types/yargs`
- Supports `--flavor` option (Postgres, MySQL, SQLite, SQL).
- Allows `npm run cli -- <filename> [--flavor=...]`.
- Example: `npm run cli -- ../your-project/database.mmd --flavor=sqlite`

Consider abstracting away `writeGeneratedFile` and `getMermaidFileContent` functions. I just copied them over from `extension.ts` and removed the vscode specific stuff from them.